### PR TITLE
[proxy] fix race condition when waiting for containers to start

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -312,7 +312,7 @@ func (proxy *Proxy) waitForStart(r *http.Request) {
 		ch = wait.ch
 	}
 	proxy.Unlock()
-	if found {
+	if ch != nil {
 		Log.Debugf("Wait for start of container %s", wait.ident)
 		<-ch
 	}


### PR DESCRIPTION
If ContainerStarted fired before the response handler, then the "waiter"
chan would be nil, and the response handler would hang.weave